### PR TITLE
Update Import-CmxServerSettings.ps1

### DIFF
--- a/Private/Import-CmxServerSettings.ps1
+++ b/Private/Import-CmxServerSettings.ps1
@@ -21,7 +21,7 @@ function Import-CmxServerSettings {
                 switch ($setKey) {
                     'NetworkAccessAccountName' {
                         Write-Log -Category "info" -Message "setting $setKey == $setVal"
-						if (Get-WmiObject -Class Win32_UserAccount | Where-Object {$_.Domain -eq "$($env:USERDOMAIN)" -and $_.Name -eq "$setVal"}) {
+						if (Get-WmiObject -Class Win32_UserAccount | Where-Object {$_.Caption -eq "$setVal"}) {
 							try {
 								Set-CMSoftwareDistributionComponent -SiteCode "$sitecode" -NetworkAccessAccountName "$setVal"
 							}


### PR DESCRIPTION
$setval is in format DOMAIN\UserName and must be used in this format for the parameter in Set-CMSoftwareDistributionComponent. So a search for caption makes more logical.